### PR TITLE
Allows using requiredIf for object in an array

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -145,7 +145,8 @@ const validate = async (schema, data, node) => {
       childErrorHash = _.fromPairs(data.map((item, i) => [
         i, validate(schema.schema, item, {
           ...node,
-          title: 'List item'
+          title: 'List item',
+          rootValue: item
         })
       ]))
       break


### PR DESCRIPTION
Sets `rootValue` to the object in the array so that the object is what gets passed to the validation rules rather than the entire tree.
